### PR TITLE
Release for v1.0.0

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+## [v1.0.0](https://github.com/michimani/simplog/commits/v1.0.0) - 2026-05-12
+- Issue/1/improve manu nav by @michimani in https://github.com/michimani/simplog/pull/4
+- hide page title in home index #5 by @michimani in https://github.com/michimani/simplog/pull/6
+- add github actions hosting demo site on github pages #7 by @michimani in https://github.com/michimani/simplog/pull/8
+- move screenshot to iamges dir #9 by @michimani in https://github.com/michimani/simplog/pull/12
+- improve pagination style #11 by @michimani in https://github.com/michimani/simplog/pull/13
+- add some meta tags, refactor css #14 by @michimani in https://github.com/michimani/simplog/pull/15
+- add logo, favicon and featured image #2 by @michimani in https://github.com/michimani/simplog/pull/16
+- fix ogp path #2 by @michimani in https://github.com/michimani/simplog/pull/17
+- fixup! fix ogp path #2 by @michimani in https://github.com/michimani/simplog/pull/18
+- show summary at list #20 by @michimani in https://github.com/michimani/simplog/pull/21
+- add Disqus #22 by @michimani in https://github.com/michimani/simplog/pull/23
+- fix theme images #19 by @michimani in https://github.com/michimani/simplog/pull/24
+- Add license scan report and status by @fossabot in https://github.com/michimani/simplog/pull/25
+- update README by @michimani in https://github.com/michimani/simplog/pull/26
+- fix example site toml #27 by @michimani in https://github.com/michimani/simplog/pull/28
+- fix head template #29 by @michimani in https://github.com/michimani/simplog/pull/30
+- add more customizations #31 by @michimani in https://github.com/michimani/simplog/pull/33
+- fix some style, and bug fix #32 by @michimani in https://github.com/michimani/simplog/pull/34
+- add lazy load shortcode #35 by @michimani in https://github.com/michimani/simplog/pull/36
+- generate CSS from SCSS #37 by @michimani in https://github.com/michimani/simplog/pull/38
+- Issue/39/some fix by @michimani in https://github.com/michimani/simplog/pull/40
+- Issue/41/additional template for adsense by @michimani in https://github.com/michimani/simplog/pull/42
+- add toggle of hide some elements #43 by @michimani in https://github.com/michimani/simplog/pull/44
+- enable cache for assets #45 by @michimani in https://github.com/michimani/simplog/pull/46
+- show original value of tags and categories #47 by @michimani in https://github.com/michimani/simplog/pull/48
+- fix value for cache buster #49 by @michimani in https://github.com/michimani/simplog/pull/50
+- Feature/51/enable header image by @michimani in https://github.com/michimani/simplog/pull/52
+- Typo in README by @jacul in https://github.com/michimani/simplog/pull/53
+- add rss link #54 by @michimani in https://github.com/michimani/simplog/pull/55
+- fixed font size discrepancy issue #56 by @michimani in https://github.com/michimani/simplog/pull/57
+- build demo site by hugo v0.105.0 by @michimani in https://github.com/michimani/simplog/pull/58
+- support Mermaid syntax by @michimani in https://github.com/michimani/simplog/pull/60
+- Bump minimist from 1.2.5 to 1.2.8 by @dependabot[bot] in https://github.com/michimani/simplog/pull/61
+- fix dependencies by @michimani in https://github.com/michimani/simplog/pull/68
+- Bump minimatch from 3.0.4 to 3.0.8 by @dependabot[bot] in https://github.com/michimani/simplog/pull/62
+- fix param name by @soralis0912 in https://github.com/michimani/simplog/pull/70
+- Bump yaml from 2.2.1 to 2.2.2 by @dependabot[bot] in https://github.com/michimani/simplog/pull/69
+- fix: update runner image to ubuntu-22.04 #71 by @michimani in https://github.com/michimani/simplog/pull/72
+- fix: baseURL of example site #73 by @michimani in https://github.com/michimani/simplog/pull/74
+- fix: parameter for relURL #73 by @michimani in https://github.com/michimani/simplog/pull/75
+- fix: use hugo.IsServer instead of site.IsServer by @michimani in https://github.com/michimani/simplog/pull/79
+- fix: example config by @michimani in https://github.com/michimani/simplog/pull/81
+- chore: set up devcontainer, migrate to pnpm, and improve dev infrastructure by @michimani in https://github.com/michimani/simplog/pull/82
+- chore: remove npm-check-updates as renovate handles dependency updates by @michimani in https://github.com/michimani/simplog/pull/87
+- chore(deps): update pnpm to v10.33.3 by @renovate[bot] in https://github.com/michimani/simplog/pull/85
+- chore: add michimani as reviewer for renovate PR by @michimani in https://github.com/michimani/simplog/pull/88


### PR DESCRIPTION
This pull request is for the next release as v1.0.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.0.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* Issue/1/improve manu nav by @michimani in https://github.com/michimani/simplog/pull/4
* hide page title in home index #5 by @michimani in https://github.com/michimani/simplog/pull/6
* add github actions hosting demo site on github pages #7 by @michimani in https://github.com/michimani/simplog/pull/8
* move screenshot to iamges dir #9 by @michimani in https://github.com/michimani/simplog/pull/12
* improve pagination style #11 by @michimani in https://github.com/michimani/simplog/pull/13
* add some meta tags, refactor css #14 by @michimani in https://github.com/michimani/simplog/pull/15
* add logo, favicon and featured image #2 by @michimani in https://github.com/michimani/simplog/pull/16
* fix ogp path #2 by @michimani in https://github.com/michimani/simplog/pull/17
* fixup! fix ogp path #2 by @michimani in https://github.com/michimani/simplog/pull/18
* show summary at list #20 by @michimani in https://github.com/michimani/simplog/pull/21
* add Disqus #22 by @michimani in https://github.com/michimani/simplog/pull/23
* fix theme images #19 by @michimani in https://github.com/michimani/simplog/pull/24
* Add license scan report and status by @fossabot in https://github.com/michimani/simplog/pull/25
* update README by @michimani in https://github.com/michimani/simplog/pull/26
* fix example site toml #27 by @michimani in https://github.com/michimani/simplog/pull/28
* fix head template #29 by @michimani in https://github.com/michimani/simplog/pull/30
* add more customizations #31 by @michimani in https://github.com/michimani/simplog/pull/33
* fix some style, and bug fix #32 by @michimani in https://github.com/michimani/simplog/pull/34
* add lazy load shortcode #35 by @michimani in https://github.com/michimani/simplog/pull/36
* generate CSS from SCSS #37 by @michimani in https://github.com/michimani/simplog/pull/38
* Issue/39/some fix by @michimani in https://github.com/michimani/simplog/pull/40
* Issue/41/additional template for adsense by @michimani in https://github.com/michimani/simplog/pull/42
* add toggle of hide some elements #43 by @michimani in https://github.com/michimani/simplog/pull/44
* enable cache for assets #45 by @michimani in https://github.com/michimani/simplog/pull/46
* show original value of tags and categories #47 by @michimani in https://github.com/michimani/simplog/pull/48
* fix value for cache buster #49 by @michimani in https://github.com/michimani/simplog/pull/50
* Feature/51/enable header image by @michimani in https://github.com/michimani/simplog/pull/52
* Typo in README by @jacul in https://github.com/michimani/simplog/pull/53
* add rss link #54 by @michimani in https://github.com/michimani/simplog/pull/55
* fixed font size discrepancy issue #56 by @michimani in https://github.com/michimani/simplog/pull/57
* build demo site by hugo v0.105.0 by @michimani in https://github.com/michimani/simplog/pull/58
* support Mermaid syntax by @michimani in https://github.com/michimani/simplog/pull/60
* Bump minimist from 1.2.5 to 1.2.8 by @dependabot[bot] in https://github.com/michimani/simplog/pull/61
* fix dependencies by @michimani in https://github.com/michimani/simplog/pull/68
* Bump minimatch from 3.0.4 to 3.0.8 by @dependabot[bot] in https://github.com/michimani/simplog/pull/62
* fix param name by @soralis0912 in https://github.com/michimani/simplog/pull/70
* Bump yaml from 2.2.1 to 2.2.2 by @dependabot[bot] in https://github.com/michimani/simplog/pull/69
* fix: update runner image to ubuntu-22.04 #71 by @michimani in https://github.com/michimani/simplog/pull/72
* fix: baseURL of example site #73 by @michimani in https://github.com/michimani/simplog/pull/74
* fix: parameter for relURL #73 by @michimani in https://github.com/michimani/simplog/pull/75
* fix: use hugo.IsServer instead of site.IsServer by @michimani in https://github.com/michimani/simplog/pull/79
* fix: example config by @michimani in https://github.com/michimani/simplog/pull/81
* chore: set up devcontainer, migrate to pnpm, and improve dev infrastructure by @michimani in https://github.com/michimani/simplog/pull/82
* chore: remove npm-check-updates as renovate handles dependency updates by @michimani in https://github.com/michimani/simplog/pull/87
* chore(deps): update pnpm to v10.33.3 by @renovate[bot] in https://github.com/michimani/simplog/pull/85
* chore: add michimani as reviewer for renovate PR by @michimani in https://github.com/michimani/simplog/pull/88

## New Contributors
* @michimani made their first contribution in https://github.com/michimani/simplog/pull/4
* @fossabot made their first contribution in https://github.com/michimani/simplog/pull/25
* @jacul made their first contribution in https://github.com/michimani/simplog/pull/53
* @dependabot[bot] made their first contribution in https://github.com/michimani/simplog/pull/61
* @soralis0912 made their first contribution in https://github.com/michimani/simplog/pull/70
* @renovate[bot] made their first contribution in https://github.com/michimani/simplog/pull/85

**Full Changelog**: https://github.com/michimani/simplog/commits/v1.0.0