### PR TITLE
Release for v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.1.1](https://github.com/michimani/simplog/compare/v1.1.0...v1.1.1) - 2026-05-15
+- chore(deps): update pnpm to v11.0.8 by @renovate[bot] in https://github.com/michimani/simplog/pull/100
+- chore: remove npm packages by @michimani in https://github.com/michimani/simplog/pull/102
+- fix: restore package.json as version file for tagpr by @michimani in https://github.com/michimani/simplog/pull/103
+
 ## [v1.1.0](https://github.com/michimani/simplog/compare/v1.0.0...v1.1.0) - 2026-05-13
 - chore(deps): update actions/checkout action to v6 by @renovate[bot] in https://github.com/michimani/simplog/pull/89
 - chore(deps): update actions/setup-node action to v6 by @renovate[bot] in https://github.com/michimani/simplog/pull/90

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "simplog",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }


### PR DESCRIPTION
This pull request is for the next release as v1.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at master -->

## What's Changed
* chore(deps): update pnpm to v11.0.8 by @renovate[bot] in https://github.com/michimani/simplog/pull/100
* chore: remove npm packages by @michimani in https://github.com/michimani/simplog/pull/102
* fix: restore package.json as version file for tagpr by @michimani in https://github.com/michimani/simplog/pull/103


**Full Changelog**: https://github.com/michimani/simplog/compare/v1.1.0...tagpr-from-v1.1.0