### PR TITLE
fix: restore package.json as version file for tagpr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "simplog",
+  "version": "1.1.0"
+}


### PR DESCRIPTION
  tagpr references package.json via .tagpr versionFile setting.
  Restore it with minimal content to fix CI failure.
