### PR TITLE
Release for v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.1.2](https://github.com/michimani/simplog/compare/v1.1.1...v1.1.2) - 2026-06-05
+
+- chore(deps): update node.js to v24.16.0 by @renovate[bot] in https://github.com/michimani/simplog/pull/104
+- chore(deps): update songmu/tagpr digest to e84001b by @renovate[bot] in https://github.com/michimani/simplog/pull/106
+- chore(deps): update actions/checkout digest to df4cb1c by @renovate[bot] in https://github.com/michimani/simplog/pull/107
+
 ## [v1.1.1](https://github.com/michimani/simplog/compare/v1.1.0...v1.1.1) - 2026-05-15
 - chore(deps): update pnpm to v11.0.8 by @renovate[bot] in https://github.com/michimani/simplog/pull/100
 - chore: remove npm packages by @michimani in https://github.com/michimani/simplog/pull/102

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "simplog",
-  "version": "1.1.1"
+  "version": "1.1.2"
 }


### PR DESCRIPTION
This pull request is for the next release as v1.1.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.1.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.1.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at master -->

## What's Changed
* chore(deps): update node.js to v24.16.0 by @renovate[bot] in https://github.com/michimani/simplog/pull/104
* chore(deps): update songmu/tagpr digest to e84001b by @renovate[bot] in https://github.com/michimani/simplog/pull/106
* chore(deps): update actions/checkout digest to df4cb1c by @renovate[bot] in https://github.com/michimani/simplog/pull/107


**Full Changelog**: https://github.com/michimani/simplog/compare/v1.1.1...tagpr-from-v1.1.1