### PR TITLE
Release for v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.1.4](https://github.com/michimani/simplog/compare/v1.1.3...v1.1.4) - 2026-08-10
+
+- chore(deps): update node.js to v24.18.1 by @renovate[bot] in https://github.com/michimani/simplog/pull/114
+- chore(deps): update node.js to v24.19.0 by @renovate[bot] in https://github.com/michimani/simplog/pull/116
+
 ## [v1.1.3](https://github.com/michimani/simplog/compare/v1.1.2...v1.1.3) - 2026-06-30
 
 - chore(deps): update node.js to v24.17.0 by @renovate[bot] in https://github.com/michimani/simplog/pull/108

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "simplog",
-  "version": "1.1.3"
+  "version": "1.1.4"
 }


### PR DESCRIPTION
This pull request is for the next release as v1.1.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.1.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.1.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at master -->

## What's Changed
* chore(deps): update node.js to v24.18.1 by @renovate[bot] in https://github.com/michimani/simplog/pull/114
* chore(deps): update node.js to v24.19.0 by @renovate[bot] in https://github.com/michimani/simplog/pull/116


**Full Changelog**: https://github.com/michimani/simplog/compare/v1.1.3...tagpr-from-v1.1.3